### PR TITLE
Optimize llm cost

### DIFF
--- a/src/graphs/admin_react.py
+++ b/src/graphs/admin_react.py
@@ -24,7 +24,7 @@ tools = [
     market_analysis
 ]
 
-executor_llm = get_llm(Config.MODEL_TYPE, is_interpreter=False)
+executor_llm = get_llm(Config.MODEL_TYPE, is_interpreter=True)
 
 # use a ReAct node to automatically choose tools and execute transactions
 react_agent = create_react_agent(

--- a/src/graphs/risk_react.py
+++ b/src/graphs/risk_react.py
@@ -17,6 +17,7 @@ tools = [
     market_analysis
 ]
 
+# Use a smarter model for reasoning and generate upadates
 executor_llm = get_llm(Config.MODEL_TYPE, is_interpreter=False)
 
 # use a ReAct node to process input data and decide if any action is needed.

--- a/src/listeners/timer_listener.py
+++ b/src/listeners/timer_listener.py
@@ -31,6 +31,9 @@ class TimerListener(Listener):
 
     async def _emit_risk_events(self):
         """Emit periodic risk update events"""
+        # Add initial delay to prevent immediate trigger
+        await asyncio.sleep(self.intervals['RISK_UPDATE'])
+        
         while self.is_running:
             try:
                 # Create and emit event
@@ -49,4 +52,4 @@ class TimerListener(Listener):
                 print("TimerListener", f"Error emitting risk event: {str(e)}")
             
             # Wait for next interval
-            await asyncio.sleep(self.intervals['RISK_UPDATE']) 
+            await asyncio.sleep(self.intervals['RISK_UPDATE'])

--- a/src/utils/reasoning.py
+++ b/src/utils/reasoning.py
@@ -11,9 +11,9 @@ import logging
 # Get the standard Python logger
 logger = logging.getLogger(__name__)
 
-
 # use smarter model for reasoning
-llm = get_llm(Config.MODEL_TYPE, is_interpreter=False)
+# for cost saving, we use the interpreter model
+llm = get_llm(Config.MODEL_TYPE, is_interpreter=True)
 
 prompt = """You are a DeFi expert in lending protocols.
 Your job is to reason about the prompt and the data, and provide a detailed analysis.


### PR DESCRIPTION
Problem: Currently, most implementations use the GPT-4o model, but its cost is relatively high, with the main expense being the output token fee of $10 per 1M tokens. In comparison, GPT-4o-mini’s output token fee is only $0.6 per 1M tokens.

![Screenshot 2025-02-26 at 5 35 28 PM](https://github.com/user-attachments/assets/e781cf5f-16de-4823-8de0-ef00fe930121)

Solution:
1. Market analysis generates the highest volume of output. Based on my testing, the output difference between the two models is minimal, so I believe the lightweight mini model is sufficient. However, the risk agent, which runs hourly, is more critical as it determines whether to execute actions and generates reports for users. Therefore, GPT-4o should still be used for this task.
2. Avoid unnecessary LLM triggers when running programs.